### PR TITLE
Options to use HTTPS and to add custom pool-specific headers to DL submission

### DIFF
--- a/blagominer/blagominer.cpp
+++ b/blagominer/blagominer.cpp
@@ -294,9 +294,8 @@ int load_config(char const *const filename)
 								Log(L"Ignoring 'ExtraHeader/%S': not a string value", item->name.GetString());
 								continue;
 							}
-							burst->network->sendextraheader += "&";
 							burst->network->sendextraheader += item->name.GetString();
-							burst->network->sendextraheader += "=";
+							burst->network->sendextraheader += ": ";
 							burst->network->sendextraheader += item->value.GetString();
 							burst->network->sendextraheader += "\r\n";
 							Log(L"ExtraHeader/%S = %S", item->name.GetString(), item->value.GetString());
@@ -429,9 +428,8 @@ int load_config(char const *const filename)
 								Log(L"Ignoring 'ExtraHeader/%S': not a string value", item->name.GetString());
 								continue;
 							}
-							bhd->network->sendextraheader += "&";
 							bhd->network->sendextraheader += item->name.GetString();
-							bhd->network->sendextraheader += "=";
+							bhd->network->sendextraheader += ": ";
 							bhd->network->sendextraheader += item->value.GetString();
 							bhd->network->sendextraheader += "\r\n";
 							Log(L"ExtraHeader/%S = %S", item->name.GetString(), item->value.GetString());

--- a/blagominer/blagominer.cpp
+++ b/blagominer/blagominer.cpp
@@ -254,6 +254,46 @@ int load_config(char const *const filename)
 
 				if (settingsBurst.HasMember("POC2StartBlock") && (settingsBurst["POC2StartBlock"].IsUint64())) burst->mining->POC2StartBlock = settingsBurst["POC2StartBlock"].GetUint64();
 				Log(L"POC2StartBlock: %llu", burst->mining->POC2StartBlock);
+
+				// TODO: refactor as 's = read-extras(s nodename)'
+				burst->network->sendextraquery = "";
+				if (settingsBurst.HasMember("ExtraQuery"))
+					if (!settingsBurst["ExtraQuery"].IsObject())
+						Log(L"Ignoring 'ExtraQuery': not a json-object");
+					else {
+						auto const& tmp = settingsBurst["ExtraQuery"].GetObjectW();
+						for (auto item = tmp.MemberBegin(); item != tmp.MemberEnd(); ++item) {
+							if (!item->value.IsString()) {
+								Log(L"Ignoring 'ExtraQuery/%S': not a string value", item->name.GetString());
+								continue;
+							}
+							burst->network->sendextraquery += "&";
+							burst->network->sendextraquery += item->name.GetString();
+							burst->network->sendextraquery += "=";
+							burst->network->sendextraquery += item->value.GetString();
+							Log(L"ExtraQuery/%S = %S", item->name.GetString(), item->value.GetString());
+						}
+					}
+
+				burst->network->sendextraheader = "";
+				if (settingsBurst.HasMember("ExtraHeader"))
+					if (!settingsBurst["ExtraHeader"].IsObject())
+						Log(L"Ignoring 'ExtraHeader': not a json-object");
+					else {
+						auto const& tmp = settingsBurst["ExtraHeader"].GetObjectW();
+						for (auto item = tmp.MemberBegin(); item != tmp.MemberEnd(); ++item) {
+							if (!item->value.IsString()) {
+								Log(L"Ignoring 'ExtraHeader/%S': not a string value", item->name.GetString());
+								continue;
+							}
+							burst->network->sendextraheader += "&";
+							burst->network->sendextraheader += item->name.GetString();
+							burst->network->sendextraheader += "=";
+							burst->network->sendextraheader += item->value.GetString();
+							burst->network->sendextraheader += "\r\n";
+							Log(L"ExtraHeader/%S = %S", item->name.GetString(), item->value.GetString());
+						}
+					}
 			}
 		}
 
@@ -343,6 +383,46 @@ int load_config(char const *const filename)
 					system("pause > nul");
 					exit(-1);
 				}
+
+				// TODO: refactor as 's = read-extras(s nodename)'
+				bhd->network->sendextraquery = "";
+				if (settingsBhd.HasMember("ExtraQuery"))
+					if (!settingsBhd["ExtraQuery"].IsObject())
+						Log(L"Ignoring 'ExtraQuery': not a json-object");
+					else {
+						auto const& tmp = settingsBhd["ExtraQuery"].GetObjectW();
+						for (auto item = tmp.MemberBegin(); item != tmp.MemberEnd(); ++item) {
+							if (!item->value.IsString()) {
+								Log(L"Ignoring 'ExtraQuery/%S': not a string value", item->name.GetString());
+								continue;
+							}
+							bhd->network->sendextraquery += "&";
+							bhd->network->sendextraquery += item->name.GetString();
+							bhd->network->sendextraquery += "=";
+							bhd->network->sendextraquery += item->value.GetString();
+							Log(L"ExtraQuery/%S = %S", item->name.GetString(), item->value.GetString());
+						}
+					}
+
+				bhd->network->sendextraheader = "";
+				if (settingsBhd.HasMember("ExtraHeader"))
+					if (!settingsBhd["ExtraHeader"].IsObject())
+						Log(L"Ignoring 'ExtraHeader': not a json-object");
+					else {
+						auto const& tmp = settingsBhd["ExtraHeader"].GetObjectW();
+						for (auto item = tmp.MemberBegin(); item != tmp.MemberEnd(); ++item) {
+							if (!item->value.IsString()) {
+								Log(L"Ignoring 'ExtraHeader/%S': not a string value", item->name.GetString());
+								continue;
+							}
+							bhd->network->sendextraheader += "&";
+							bhd->network->sendextraheader += item->name.GetString();
+							bhd->network->sendextraheader += "=";
+							bhd->network->sendextraheader += item->value.GetString();
+							bhd->network->sendextraheader += "\r\n";
+							Log(L"ExtraHeader/%S = %S", item->name.GetString(), item->value.GetString());
+						}
+					}
 			}
 		}
 				

--- a/blagominer/blagominer.cpp
+++ b/blagominer/blagominer.cpp
@@ -1114,6 +1114,10 @@ void closeMiner() {
 		closesocket((*it)->Socket);
 	}
 	burst->network->sessions.clear();
+	for (auto it = burst->network->sessions2.begin(); it != burst->network->sessions2.end(); ++it) {
+		curl_easy_cleanup((*it)->curl);
+	}
+	burst->network->sessions2.clear();
 	LeaveCriticalSection(&burst->locks->sessionsLock);
 
 	EnterCriticalSection(&bhd->locks->sessionsLock);
@@ -1121,6 +1125,10 @@ void closeMiner() {
 		closesocket((*it)->Socket);
 	}
 	bhd->network->sessions.clear();
+	for (auto it = bhd->network->sessions2.begin(); it != bhd->network->sessions2.end(); ++it) {
+		curl_easy_cleanup((*it)->curl);
+	}
+	bhd->network->sessions2.clear();
 	LeaveCriticalSection(&bhd->locks->sessionsLock);
 	if (pass != nullptr) HeapFree(hHeap, 0, pass);
 		
@@ -1152,9 +1160,11 @@ void closeMiner() {
 	burst->mining->bests.~vector();
 	burst->mining->shares.~vector();
 	burst->network->sessions.~vector();
+	burst->network->sessions2.~vector();
 	bhd->mining->bests.~vector();
 	bhd->mining->shares.~vector();
 	bhd->network->sessions.~vector();
+	bhd->network->sessions2.~vector();
 }
 
 BOOL WINAPI OnConsoleClose(DWORD dwCtrlType)
@@ -1276,6 +1286,7 @@ int main(int argc, char **argv) {
 		burst->mining->shares.reserve(20);
 		burst->mining->bests.reserve(4);
 		burst->network->sessions.reserve(20);
+		burst->network->sessions2.reserve(20);
 
 		char* updateripBurst = (char*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, 50);
 		if (updateripBurst == nullptr) ShowMemErrorExit();
@@ -1312,6 +1323,7 @@ int main(int argc, char **argv) {
 		bhd->mining->shares.reserve(20);
 		bhd->mining->bests.reserve(4);
 		bhd->network->sessions.reserve(20);
+		bhd->network->sessions2.reserve(20);
 
 		char* updateripBhd = (char*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, 50);
 		if (updateripBhd == nullptr) ShowMemErrorExit();

--- a/blagominer/blagominer.cpp
+++ b/blagominer/blagominer.cpp
@@ -255,6 +255,12 @@ int load_config(char const *const filename)
 				if (settingsBurst.HasMember("POC2StartBlock") && (settingsBurst["POC2StartBlock"].IsUint64())) burst->mining->POC2StartBlock = settingsBurst["POC2StartBlock"].GetUint64();
 				Log(L"POC2StartBlock: %llu", burst->mining->POC2StartBlock);
 
+				if (settingsBurst.HasMember("UseHTTPS"))
+					if (!settingsBurst["UseHTTPS"].IsBool())
+						Log(L"Ignoring 'UseHTTPS': not a boolean");
+					else
+						burst->network->usehttps = settingsBurst["UseHTTPS"].GetBool();
+
 				// TODO: refactor as 's = read-extras(s nodename)'
 				burst->network->sendextraquery = "";
 				if (settingsBurst.HasMember("ExtraQuery"))
@@ -383,6 +389,12 @@ int load_config(char const *const filename)
 					system("pause > nul");
 					exit(-1);
 				}
+
+				if (settingsBhd.HasMember("UseHTTPS"))
+					if (!settingsBhd["UseHTTPS"].IsBool())
+						Log(L"Ignoring 'UseHTTPS': not a boolean");
+					else
+						bhd->network->usehttps = settingsBhd["UseHTTPS"].GetBool();
 
 				// TODO: refactor as 's = read-extras(s nodename)'
 				bhd->network->sendextraquery = "";

--- a/blagominer/blagominer.cpp
+++ b/blagominer/blagominer.cpp
@@ -2,6 +2,8 @@
 #include "stdafx.h"
 #include "blagominer.h"
 
+#include <curl/curl.h>
+
 bool exitHandled = false;
 
 // Initialize static member data
@@ -1138,6 +1140,7 @@ void closeMiner() {
 		HeapFree(hHeap, 0, p_minerPath);
 	}
 
+	curl_global_cleanup();
 	WSACleanup();
 	Log(L"exit");
 	Log_end();
@@ -1210,6 +1213,9 @@ int main(int argc, char **argv) {
 	}
 	else sprintf_s(conf_filename, MAX_PATH, "%s%s", p_minerPath, "miner.conf");
 	
+	// init 3rd party libs
+	curl_global_init(CURL_GLOBAL_DEFAULT);
+
 	// Initialize configuration.
 	init_mining_info();
 	init_network_info();

--- a/blagominer/blagominer.cpp
+++ b/blagominer/blagominer.cpp
@@ -820,6 +820,10 @@ void newRound(std::shared_ptr<t_coin_info > coinCurrentlyMining) {
 		closesocket((*it)->Socket);
 	}
 	coinCurrentlyMining->network->sessions.clear();
+	for (auto it = coinCurrentlyMining->network->sessions2.begin(); it != coinCurrentlyMining->network->sessions2.end(); ++it) {
+		curl_easy_cleanup((*it)->curl);
+	}
+	coinCurrentlyMining->network->sessions2.clear();
 	LeaveCriticalSection(&coinCurrentlyMining->locks->sessionsLock);
 
 	EnterCriticalSection(&coinCurrentlyMining->locks->sharesLock);

--- a/blagominer/blagominer.cpp
+++ b/blagominer/blagominer.cpp
@@ -1126,11 +1126,13 @@ void closeMiner() {
 		
 	if (burst->mining->enable || burst->network->enable_proxy) {
 		DeleteCriticalSection(&burst->locks->sessionsLock);
+		DeleteCriticalSection(&burst->locks->sessions2Lock);
 		DeleteCriticalSection(&burst->locks->sharesLock);
 		DeleteCriticalSection(&burst->locks->bestsLock);
 	}
 	if (bhd->mining->enable || bhd->network->enable_proxy) {
 		DeleteCriticalSection(&bhd->locks->sessionsLock);
+		DeleteCriticalSection(&bhd->locks->sessions2Lock);
 		DeleteCriticalSection(&bhd->locks->sharesLock);
 		DeleteCriticalSection(&bhd->locks->bestsLock);
 	}
@@ -1268,6 +1270,7 @@ int main(int argc, char **argv) {
 	if (burst->mining->enable || burst->network->enable_proxy) {
 
 		InitializeCriticalSection(&burst->locks->sessionsLock);
+		InitializeCriticalSection(&burst->locks->sessions2Lock);
 		InitializeCriticalSection(&burst->locks->bestsLock);
 		InitializeCriticalSection(&burst->locks->sharesLock);
 		burst->mining->shares.reserve(20);
@@ -1303,6 +1306,7 @@ int main(int argc, char **argv) {
 
 	if (bhd->mining->enable || bhd->network->enable_proxy) {
 		InitializeCriticalSection(&bhd->locks->sessionsLock);
+		InitializeCriticalSection(&bhd->locks->sessions2Lock);
 		InitializeCriticalSection(&bhd->locks->bestsLock);
 		InitializeCriticalSection(&bhd->locks->sharesLock);
 		bhd->mining->shares.reserve(20);

--- a/blagominer/blagominer.vcxproj
+++ b/blagominer/blagominer.vcxproj
@@ -711,6 +711,5 @@
     <None Include="cpp.hint" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/blagominer/blagominer.vcxproj.filters
+++ b/blagominer/blagominer.vcxproj.filters
@@ -148,4 +148,7 @@
       <Filter>Ressourcendateien</Filter>
     </Image>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="cpp.hint" />
+  </ItemGroup>
 </Project>

--- a/blagominer/common.h
+++ b/blagominer/common.h
@@ -150,6 +150,7 @@ struct t_network_info {
 	size_t update_interval;
 	size_t proxy_update_interval;
 	int network_quality;
+	bool usehttps;
 	std::string sendextraquery;
 	std::string sendextraheader;
 	std::vector<std::shared_ptr<t_session>> sessions;

--- a/blagominer/common.h
+++ b/blagominer/common.h
@@ -7,6 +7,8 @@
 #include <math.h>
 #include "logger.h"
 
+#include <curl/curl.h>
+
 // blago version
 extern const unsigned int versionMajor;
 extern const unsigned int versionMinor;
@@ -66,6 +68,12 @@ struct t_session {
 	unsigned long long deadline;
 	t_shares body;
 };
+struct t_session2 {
+	t_session2(CURL* curl, unsigned long long deadline, t_shares body) : curl(curl), deadline(deadline), body(body) {}
+	CURL* curl;
+	unsigned long long deadline;
+	t_shares body;
+};
 
 struct t_files {
 	bool done;
@@ -105,6 +113,7 @@ struct t_locks {
 	std::mutex mNewMiningInfoReceived;
 
 	CRITICAL_SECTION sessionsLock;			// session lock
+	CRITICAL_SECTION sessions2Lock;			// session2 lock
 	CRITICAL_SECTION bestsLock;				// best lock
 	CRITICAL_SECTION sharesLock;			// shares lock
 };
@@ -154,6 +163,7 @@ struct t_network_info {
 	std::string sendextraquery;
 	std::string sendextraheader;
 	std::vector<std::shared_ptr<t_session>> sessions;
+	std::vector<std::shared_ptr<t_session2>> sessions2;
 	std::thread sender;
 	std::thread confirmer;
 };

--- a/blagominer/common.h
+++ b/blagominer/common.h
@@ -150,6 +150,8 @@ struct t_network_info {
 	size_t update_interval;
 	size_t proxy_update_interval;
 	int network_quality;
+	std::string sendextraquery;
+	std::string sendextraheader;
 	std::vector<std::shared_ptr<t_session>> sessions;
 	std::thread sender;
 	std::thread confirmer;

--- a/blagominer/miner.conf
+++ b/blagominer/miner.conf
@@ -8,6 +8,7 @@
         "Mode" : "pool",                                // Mining mode: "pool" or "solo"
         "Server" : "pool.dev.burst-test.net",           // Submit deadlines to this address and port
         "Port" : "8124",
+		//"UseHTTPS": true,								// uncomment to turn on HTTPS support for this coin, ensure that PORT is also correct for HTTPS
 
         "SubmitTimeout" : 1500,                         // Timeout in milliseconds after a deadline submission is regarded as failed.
                                                         // Increase this value if deadlines are being resent too many times.
@@ -50,6 +51,7 @@
 
         "Server" : "localhost",                         // Submit deadlines to this address and port
         "Port" : "8732",
+		//"UseHTTPS": true,								// uncomment to turn on HTTPS support for this coin, ensure that PORT is also correct for HTTPS
 
         "SubmitTimeout" : 1500,                         // Timeout in milliseconds after a deadline submission is regarded as failed.
                                                         // Increase this value if deadlines are being resent too many times.

--- a/blagominer/miner.conf
+++ b/blagominer/miner.conf
@@ -24,7 +24,23 @@
 
         "TargetDeadline" : 32000000,                    // Target deadline in seconds
 
-        "POC2StartBlock" : 502000                       // The block height PoC2 format started
+        "POC2StartBlock" : 502000,                      // The block height PoC2 format started
+
+		"ExtraHeader": {
+			// ignored in SOLO mode, only used in POOL mode
+			// add as many fields as you like, values must be string
+			// all of these values will be sent as additional headers to the pool
+			// warning: values are not sanitized, you must make them header-safe
+			// "X-Account": "your accountKey",
+			// "X-MinerName": "some cool name"
+		},
+
+		"ExtraQuery": {
+			// ignored in SOLO mode, only used in POOL mode
+			// add as many fields as you like, values must be string
+			// all of these values will be sent as additional url parameters to the pool
+			// warning: values are not sanitized, you must make them url-safe
+		}
    },
 
     "BHD" : {                                           // Configuration for Bitcoin HD mining
@@ -48,7 +64,23 @@
         "SendInterval": 100,                            // Interval in milliseconds for the sender thread checking for new deadlines found during mining
         "UpdateInterval": 450,                          // Interval in milliseconds for the updater thread checking for new mining information
 
-        "TargetDeadline" : 32000000                     // Target deadline in seconds
+        "TargetDeadline" : 32000000,                    // Target deadline in seconds
+
+		"ExtraHeader": {
+			// ignored in SOLO mode, only used in POOL mode
+			// add as many fields as you like, values must be string
+			// all of these values will be sent as additional headers to the pool
+			// warning: values are not sanitized, you must make them header-safe
+			// "X-Account": "your accountKey",
+			// "X-MinerName": "some cool name"
+		},
+
+		"ExtraQuery": {
+			// ignored in SOLO mode, only used in POOL mode
+			// add as many fields as you like, values must be string
+			// all of these values will be sent as additional url parameters to the pool
+			// warning: values are not sanitized, you must make them url-safe
+		}
     },
 
     "Paths" : ["d:\\plot"],                             // List of directories containing the plot files. Examples:

--- a/blagominer/network.cpp
+++ b/blagominer/network.cpp
@@ -391,6 +391,7 @@ void send_i(std::shared_ptr<t_coin_info> coinInfo)
 	if (buffer == nullptr) ShowMemErrorExit();
 
 	std::vector<std::shared_ptr<t_session>> tmpSessions;
+	std::vector<std::shared_ptr<t_session2>> tmpSessions2;
 
 	while (!exit_flag) {
 		std::shared_ptr<t_shares> share;
@@ -411,6 +412,14 @@ void send_i(std::shared_ptr<t_coin_info> coinInfo)
 				}
 				LeaveCriticalSection(&coinInfo->locks->sessionsLock);
 				tmpSessions.clear();
+			}
+			if (!tmpSessions2.empty()) {
+				EnterCriticalSection(&coinInfo->locks->sessions2Lock);
+				for (auto& session : tmpSessions2) {
+					coinInfo->network->sessions2.push_back(session);
+				}
+				LeaveCriticalSection(&coinInfo->locks->sessions2Lock);
+				tmpSessions2.clear();
 			}
 
 			std::this_thread::yield();

--- a/blagominer/network.cpp
+++ b/blagominer/network.cpp
@@ -629,6 +629,8 @@ bool __impl__confirm_i__sockets(char* buffer, size_t buffer_size, std::shared_pt
 			confirmerName, session->deadline, session->body.height, coinInfo->mining->currentHeight);
 		EnterCriticalSection(&coinInfo->locks->sessionsLock);
 		if (!coinInfo->network->sessions.empty()) {
+			iResult = closesocket(coinInfo->network->sessions.front()->Socket);
+			Log(L"Confirmer %s: Close socket. Code = %i", confirmerName, WSAGetLastError());
 			coinInfo->network->sessions.erase(coinInfo->network->sessions.begin());
 		}
 		LeaveCriticalSection(&coinInfo->locks->sessionsLock);
@@ -660,6 +662,8 @@ bool __impl__confirm_i__sockets(char* buffer, size_t buffer_size, std::shared_pt
 			Log(L"Confirmer %s: ! Error getting confirmation for DL: %llu  code: %i", confirmerName, session->deadline, WSAGetLastError());
 			EnterCriticalSection(&coinInfo->locks->sessionsLock);
 			if (!coinInfo->network->sessions.empty()) {
+				iResult = closesocket(coinInfo->network->sessions.front()->Socket);
+				Log(L"Confirmer %s: Close socket. Code = %i", confirmerName, WSAGetLastError());
 				coinInfo->network->sessions.erase(coinInfo->network->sessions.begin());
 			}
 			LeaveCriticalSection(&coinInfo->locks->sessionsLock);
@@ -758,10 +762,10 @@ bool __impl__confirm_i__sockets(char* buffer, size_t buffer_size, std::shared_pt
 				nonJsonSuccessDetected = false;
 			}
 		}
-		iResult = closesocket(ConnectSocket);
-		Log(L"Confirmer %s: Close socket. Code = %i", confirmerName, WSAGetLastError());
 		EnterCriticalSection(&coinInfo->locks->sessionsLock);
 		if (!coinInfo->network->sessions.empty()) {
+			iResult = closesocket(coinInfo->network->sessions.front()->Socket);
+			Log(L"Confirmer %s: Close socket. Code = %i", confirmerName, WSAGetLastError());
 			coinInfo->network->sessions.erase(coinInfo->network->sessions.begin());
 		}
 		LeaveCriticalSection(&coinInfo->locks->sessionsLock);

--- a/blagominer/network.cpp
+++ b/blagominer/network.cpp
@@ -797,6 +797,8 @@ bool __impl__confirm_i__curl(std::shared_ptr<t_coin_info> coinInfo, rapidjson::D
 			confirmerName, session->deadline, session->body.height, coinInfo->mining->currentHeight);
 		EnterCriticalSection(&coinInfo->locks->sessions2Lock);
 		if (!coinInfo->network->sessions2.empty()) {
+			curl_easy_cleanup(coinInfo->network->sessions2.front()->curl);
+			Log(L"Confirmer %s: Close socket.", confirmerName);
 			coinInfo->network->sessions2.erase(coinInfo->network->sessions2.begin());
 		}
 		LeaveCriticalSection(&coinInfo->locks->sessions2Lock);
@@ -849,6 +851,8 @@ bool __impl__confirm_i__curl(std::shared_ptr<t_coin_info> coinInfo, rapidjson::D
 
 		EnterCriticalSection(&coinInfo->locks->sessions2Lock);
 		if (!coinInfo->network->sessions2.empty()) {
+			curl_easy_cleanup(coinInfo->network->sessions2.front()->curl);
+			Log(L"Confirmer %s: Close socket.", confirmerName);
 			coinInfo->network->sessions2.erase(coinInfo->network->sessions2.begin());
 		}
 		LeaveCriticalSection(&coinInfo->locks->sessions2Lock);
@@ -945,10 +949,10 @@ bool __impl__confirm_i__curl(std::shared_ptr<t_coin_info> coinInfo, rapidjson::D
 				nonJsonSuccessDetected = false;
 			}
 		}
-		curl_easy_cleanup(curl);
-		Log(L"Confirmer %s: Close socket.", confirmerName);
 		EnterCriticalSection(&coinInfo->locks->sessions2Lock);
 		if (!coinInfo->network->sessions2.empty()) {
+			curl_easy_cleanup(coinInfo->network->sessions2.front()->curl);
+			Log(L"Confirmer %s: Close socket.", confirmerName);
 			coinInfo->network->sessions2.erase(coinInfo->network->sessions2.begin());
 		}
 		LeaveCriticalSection(&coinInfo->locks->sessions2Lock);

--- a/blagominer/network.cpp
+++ b/blagominer/network.cpp
@@ -1226,8 +1226,8 @@ bool __impl__pollLocal__sockets(std::shared_ptr<t_coin_info> coinInfo, rapidjson
 					}
 				}
 			}
-			iResult = closesocket(UpdaterSocket);
 		}
+		iResult = closesocket(UpdaterSocket);
 		freeaddrinfo(result);
 	}
 	if (buffer != nullptr) {

--- a/blagominer/network.cpp
+++ b/blagominer/network.cpp
@@ -293,7 +293,8 @@ void __impl__send_i__sockets(char* buffer, size_t buffer_size, std::shared_ptr<t
 {
 	const wchar_t* senderName = coinNames[coinInfo->coin];
 
-	SOCKET ConnectSocket;
+	SOCKET ConnectSocket = INVALID_SOCKET;
+	std::unique_ptr<SOCKET, void(*)(SOCKET*)> guardConnectSocket(&ConnectSocket, [](SOCKET* s) {closesocket(*s); });
 
 	int iResult = 0;
 
@@ -369,6 +370,7 @@ void __impl__send_i__sockets(char* buffer, size_t buffer_size, std::shared_ptr<t
 				share->deadline % 60);
 
 			tmpSessions.push_back(std::make_shared<t_session>(ConnectSocket, share->deadline, *share));
+			guardConnectSocket.release();
 
 			Log(L"[%20llu] Sender %s: Setting bests targetDL: %10llu", share->account_id, senderName, share->deadline);
 			coinInfo->mining->bests[Get_index_acc(share->account_id, coinInfo, targetDeadlineInfo)].targetDeadline = share->deadline;

--- a/blagominer/network.cpp
+++ b/blagominer/network.cpp
@@ -403,7 +403,9 @@ void send_i(std::shared_ptr<t_coin_info> coinInfo)
 			{
 				unsigned long long total = total_size / 1024 / 1024 / 1024;
 				for (auto It = satellite_size.begin(); It != satellite_size.end(); ++It) total = total + It->second;
-				bytes = sprintf_s(buffer, buffer_size, "POST /burst?requestType=submitNonce&accountId=%llu&nonce=%llu&deadline=%llu HTTP/1.0\r\nHost: %s:%s\r\nX-Miner: Blago %S\r\nX-Capacity: %llu\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", share->account_id, share->nonce, share->best, coinInfo->network->nodeaddr.c_str(), coinInfo->network->nodeport.c_str(), version.c_str(), total);
+
+				char const* format = "POST /burst?requestType=submitNonce&accountId=%llu&nonce=%llu&deadline=%llu%S HTTP/1.0\r\nHost: %s:%s\r\nX-Miner: Blago %S\r\nX-Capacity: %llu\r\n%SContent-Length: 0\r\nConnection: close\r\n\r\n";
+				bytes = sprintf_s(buffer, buffer_size, format, share->account_id, share->nonce, share->best, coinInfo->network->sendextraquery.c_str(), coinInfo->network->nodeaddr.c_str(), coinInfo->network->nodeport.c_str(), version.c_str(), total, coinInfo->network->sendextraheader.c_str());
 			}
 
 			// Sending to server

--- a/blagominer/network.cpp
+++ b/blagominer/network.cpp
@@ -804,16 +804,16 @@ bool __impl__pollLocal__sockets(std::shared_ptr<t_coin_info> coinInfo, rapidjson
 							Log(L"* GMI %s: Received: %S", updaterName, Log_server(buffer).c_str());
 						}
 
+						rawResponse = buffer;
+						rapidjson::Document& gmi = output;
+
 						// locate HTTP header
-						char *find = strstr(buffer, "\r\n\r\n");
+						char const* find = strstr(buffer, "\r\n\r\n");
 						if (find == nullptr) {
 							Log(L"*! GMI %s: error message from pool: %S", updaterName, Log_server(buffer).c_str());
 							failed = true;
 						}
-
-						rawResponse = buffer;
-						rapidjson::Document& gmi = output;
-						if (loggingConfig.logAllGetMiningInfos && gmi.Parse<0>(find).HasParseError()) {
+						else if (loggingConfig.logAllGetMiningInfos && gmi.Parse<0>(find).HasParseError()) {
 							Log(L"*! GMI %s: error parsing JSON message from pool", updaterName);
 							failed = true;
 						}

--- a/blagominer/network.cpp
+++ b/blagominer/network.cpp
@@ -392,7 +392,7 @@ void __impl__send_i__curl(std::shared_ptr<t_coin_info> coinInfo, std::vector<std
 	char *buffer = (char*)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, buffer_size);
 	if (buffer == nullptr) ShowMemErrorExit();
 
-	CURL* curl = curl_easy_init();
+	std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> curl(curl_easy_init(), &curl_easy_cleanup);
 	if (!curl) {
 		failed = true;
 	}
@@ -408,7 +408,7 @@ void __impl__send_i__curl(std::shared_ptr<t_coin_info> coinInfo, std::vector<std
 			 * default bundle, then the CURLOPT_CAPATH option might come handy for
 			 * you.
 			 */
-			curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+			curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 0L);
 		}
 
 		if (false) { // coinInfo->network->SKIP_HOSTNAME_VERIFICATION
@@ -418,7 +418,7 @@ void __impl__send_i__curl(std::shared_ptr<t_coin_info> coinInfo, std::vector<std
 			 * subjectAltName) fields, libcurl will refuse to connect. You can skip
 			 * this check, but this will make the connection less secure.
 			 */
-			curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+			curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 0L);
 		}
 
 		std::string root = "https://";
@@ -426,15 +426,15 @@ void __impl__send_i__curl(std::shared_ptr<t_coin_info> coinInfo, std::vector<std
 		root += ":";
 		root += coinInfo->network->nodeport;
 
-		curl_easy_setopt(curl, CURLOPT_URL, root.c_str());
-		curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);
-		curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, coinInfo->network->submitTimeout);
+		curl_easy_setopt(curl.get(), CURLOPT_URL, root.c_str());
+		curl_easy_setopt(curl.get(), CURLOPT_CONNECT_ONLY, 1L);
+		curl_easy_setopt(curl.get(), CURLOPT_TIMEOUT_MS, coinInfo->network->submitTimeout);
 
-		CURLcode res = curl_easy_perform(curl);
+		CURLcode res = curl_easy_perform(curl.get());
 
 		curl_socket_t sockfd;
 		if (res == CURLE_OK) {
-			res = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd);
+			res = curl_easy_getinfo(curl.get(), CURLINFO_ACTIVESOCKET, &sockfd);
 		}
 
 		if (res == CURLE_OK) {
@@ -464,7 +464,7 @@ void __impl__send_i__curl(std::shared_ptr<t_coin_info> coinInfo, std::vector<std
 			size_t total_sent = 0;
 			do {
 				size_t sent = 0;
-				res = curl_easy_send(curl, buffer + total_sent, bytes - total_sent, &sent);
+				res = curl_easy_send(curl.get(), buffer + total_sent, bytes - total_sent, &sent);
 				total_sent += sent;
 				if (total_sent >= bytes)
 					break;
@@ -500,7 +500,8 @@ void __impl__send_i__curl(std::shared_ptr<t_coin_info> coinInfo, std::vector<std
 				(share->deadline % (60 * 60)) / 60,
 				share->deadline % 60);
 
-			tmpSessions.push_back(std::make_shared<t_session2>(curl, share->deadline, *share));
+			tmpSessions.push_back(std::make_shared<t_session2>(curl.get(), share->deadline, *share));
+			curl.release();
 
 			Log(L"[%20llu] Sender %s: Setting bests targetDL: %10llu", share->account_id, senderName, share->deadline);
 			coinInfo->mining->bests[Get_index_acc(share->account_id, coinInfo, targetDeadlineInfo)].targetDeadline = share->deadline;


### PR DESCRIPTION
(this is a copy of PR #4 - I accidentally PR'ed from master, now I made a separate branch for that)

Actually, this could be 2 or even 3 PRs but during coding session I stacked one change upon the other, it all touches networking areas, so it's probably no use in splitting them into separate updates.

There are two major changes.

### Custom headers

First of all, some pools (especially BHD ones) require to send some form of account-id along with the submission. Usually, this means that a 'proxy' must also be used to inject that information, which only makes the learning curve steeper and has no benefits for small miners.

I've extended the config.json with new options, now it is possible to configure the miner to send headers like X-Account or X-MinerName or X-ShoeSize just by editing the config.json. and updated the sample config.json

As a "bonus" I also added a similar section that allows to add extra query parameters in a similar way. I don't know about any pool that would need that, but it was just a "copy-paste" problem and makes the miner a little bit more future-proof.

New config sections are separate for both coins and are pretty simple, like:

```
    "BHD" : {    
                ...
		"ExtraHeader": {
			"X-Account": "0000-1111-98qr7348errfi8efxny-OK",
			"X-MinerName": "some cool name",
			"X-ShoeSize": "23.5"
		},
                ...
```

### HTTPS support

Now that's a larger update. So far GMI, send_i, confirm_i were using sockets directly and worked over plain HTTP. This causes some serious issues, for example pools hidden behind CloudFlare, when receiving HTTP request, may return HTTP/302 to try to enforce HTTPS. In this case, the miner simply does not handle the redirect and treats it as a failed request, but even if it followed the redirect, it would fail due to lack of support for HTTPS.

With this PR, I've implemented HTTPS connectivity via CURL. I've also deliberately left all of the old code. New CURL code is used only for HTTPS, and the old code is used otherwise. HTTPS is off by default and needs to be explicitely turned on by a single flag:

```
    "BHD" : {    
                ...
		"UseHTTPS": true,
                ...
```

and of course the `"Port"` may have to be updated as well.

Right now, HTTPS is implemented only for the basic mining.
"Proxy" mode has not been updated to use HTTPS and still uses existing HTTP code.

### Building, testing

I used vcpkg to provide dependencies.
I was building it with:

- pdcurses 3.6 x64-windows
- curl 7.65.0-1 x64-windows

I also did some preliminary testing. Mining works, GMI/send/confirm work over http and https (tested on foxy pool). AccountKey is sent properly (also tested on foxy pool). Miner worked for 8hrs and has not crashed, and has sent all DLs. Survived intermittent 502/badgateway from cloudflare and local network loses. Sounds like working fine.

### Performance

I have no idea. I didn't notice anything drastic. but my test plots were small. It shouldn't matter much, as only networking code was changed, but HTTPS will have some impact (handshakes, etc) and also changing from SOCKETS to CURL may have some impact, there are some extra networking buffer allocations as well. I personally wouldn't worry about that, but YMMV.